### PR TITLE
removed unwanted "{{Gallery" and "{{Taxobox" from

### DIFF
--- a/index.js
+++ b/index.js
@@ -405,7 +405,7 @@ var wtf_wikipedia=(function(){
         if(s.match(infobox_reg, "ig") && Object.keys(infobox).length==0){
           infobox= parse_infobox(s)
         }
-        if(s.match(/\{\{(cite|infobox|Inligtingskas|sister|geographic|navboxes|listen|historical|citeweb|citenews|lien|clima|cita|Internetquelle|article|weather)[ \|:\n]/i)){
+        if(s.match(/\{\{(Gallery|Taxobox|cite|infobox|Inligtingskas|sister|geographic|navboxes|listen|historical|citeweb|citenews|lien|clima|cita|Internetquelle|article|weather)[ \|:\n]/i)){
           wiki=wiki.replace(s,'')
         }
       })


### PR DESCRIPTION
After pull, eg, from http://en.wikipedia.org/wiki/Leopard, ugly "{{Gallery" and "{{Taxobox" remained in text. This takes care of that problem.
